### PR TITLE
Update pull_request trigger to include specific paths

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -1,6 +1,9 @@
 name: Ansible CI
 
-on: [pull_request]
+on:
+  pull_request:
+    paths:
+      - "ansible/**"
 
 jobs:
   build:


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/ansible.yml` file to specify the paths that trigger the Ansible CI workflow. Previously, the workflow was triggered by any pull request, but now it will only be triggered by pull requests that modify files in the `ansible` directory.