### PR TITLE
Add task to download, extract, and copy purl binary

### DIFF
--- a/ansible/roles/purl/tasks/main.yml
+++ b/ansible/roles/purl/tasks/main.yml
@@ -1,0 +1,18 @@
+- name: Download purl
+  get_url:
+    url: https://github.com/catatsuy/purl/releases/latest/download/purl-linux-{{ arch_res.stdout }}.tar.gz
+    dest: /tmp/purl-linux.tar.gz
+
+- name: Extract purl
+  unarchive:
+    src: /tmp/purl-linux.tar.gz
+    dest: /tmp/
+    remote_src: yes
+
+- name: Copy to /usr/local/bin/
+  become: yes
+  copy:
+    src: /tmp/purl
+    dest: /usr/local/bin/
+    remote_src: yes
+    mode: "0755"

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -14,6 +14,10 @@
       tags:
         - nginx_build
 
+    - role: purl
+      tags:
+        - purl
+
     - role: alp
       tags:
         - alp


### PR DESCRIPTION
This pull request includes changes to the `ansible/roles/purl/tasks/main.yml` file. The changes primarily focus on the process of downloading, extracting, and copying the `purl` tool. 

* [`ansible/roles/purl/tasks/main.yml`](diffhunk://#diff-28f58cd426a106280ddfa79e759e0dfc6179e58a63d8d64c863bae1163c77d66R1-R18): The process of downloading `purl` has been changed to use the `get_url` module, which downloads the file from a specified URL and saves it to a destination on the remote machine. The extraction process has also been updated to use the `unarchive` module, which extracts files from a tarball. Lastly, the `copy` module is used to copy the `purl` file to `/usr/local/bin/` with the appropriate permissions.