### PR TITLE
Remove unnecessary job id from ansible workflow

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -37,4 +37,3 @@ jobs:
         run: |
           cd ansible
           ansible-playbook --check --diff -i test site.yml
-        id: check_playbook


### PR DESCRIPTION
This pull request includes a minor change to the `.github/workflows/ansible.yml` file. The `id: check_playbook` line has been removed from the `jobs:` section. This change simplifies the workflow by removing an unnecessary ID assignment.