### PR TITLE
Update notify_slack to fetch the latest release and remove version

### DIFF
--- a/ansible/roles/notify_slack/defaults/main.yml
+++ b/ansible/roles/notify_slack/defaults/main.yml
@@ -1,3 +1,0 @@
----
-# datasource=github-releases depName=catatsuy/notify_slack
-notify_slack_version: 0.5.0

--- a/ansible/roles/notify_slack/tasks/main.yml
+++ b/ansible/roles/notify_slack/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: Download notify_slack
   get_url:
-    url: https://github.com/catatsuy/notify_slack/releases/download/v{{ notify_slack_version }}/notify_slack-linux-{{ arch_res.stdout }}.tar.gz
+    url: https://github.com/catatsuy/notify_slack/releases/latest/download/notify_slack-linux-{{ arch_res.stdout }}.tar.gz
     dest: /tmp/notify_slack-linux.tar.gz
 
 - name: Extract notify_slack


### PR DESCRIPTION
This pull request includes changes to the `ansible/roles/notify_slack` role for Ansible. The changes involve updating the way the `notify_slack` tool is downloaded and installed.

Here are the most important changes:

* [`ansible/roles/notify_slack/defaults/main.yml`](diffhunk://#diff-0b263107e19e206fc838c97f2e52a616479a578be9ad63b2c9f677e83bbdfeb9L1-L3): Removed hardcoded version number for `notify_slack` tool.
* [`ansible/roles/notify_slack/tasks/main.yml`](diffhunk://#diff-1a0e7ace24bb6ec61f9e430d5d057146d5c532d9f3f0bbf2e329f4053f87064fL3-R3): Updated the download URL in the `get_url` task to always fetch the latest release of `notify_slack` from GitHub.

These changes ensure that the latest version of `notify_slack` is always used, reducing the need for manual updates.