### PR TITLE
Remove --diff flag from Ansible playbook commands in workflow file

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -31,9 +31,9 @@ jobs:
       - name: Run Ansible playbook
         run: |
           cd ansible
-          ansible-playbook --diff -i test site.yml
+          ansible-playbook -i test site.yml
 
       - name: Run Ansible playbook in check mode
         run: |
           cd ansible
-          ansible-playbook --check --diff -i test site.yml
+          ansible-playbook --check -i test site.yml


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/ansible.yml` file to simplify the Ansible playbook commands by removing the `--diff` flag.

Simplification of Ansible playbook commands:

* [`.github/workflows/ansible.yml`](diffhunk://#diff-d082b5b4fe275099cf3ff019037522eae61f3a8091073938ecbfcc153f341ba8L34-R39): Removed the `--diff` flag from the Ansible playbook commands to streamline the execution process.