### PR TITLE
Add link to Go in-memory cache repository in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,6 +533,8 @@ curl --unix-socket server.sock http:/
 
 ### Goでインメモリキャッシュ
 
+https://github.com/catatsuy/cache
+
 ``` go
 type cache[K comparable, V any] struct {
 	// Setが多いならsync.Mutex


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change adds a link to the `cache` GitHub repository for reference.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R536-R537): Added a link to the `cache` GitHub repository for additional information.