### PR TITLE
Here's how I updated nginx-build to install the latest version:

### DIFF
--- a/ansible/roles/nginx_build/tasks/main.yml
+++ b/ansible/roles/nginx_build/tasks/main.yml
@@ -1,8 +1,22 @@
+- name: Get system architecture
+  command: dpkg --print-architecture
+  register: arch_res
+  changed_when: false
+  check_mode: no
+
 - name: Get latest nginx-build version
   uri:
     url: https://api.github.com/repos/cubicdaiya/nginx-build/releases/latest
     body_format: json
   register: nginx_latest_release
+
+- name: Assert that tag_name is available
+  assert:
+    that:
+      - nginx_latest_release.json is defined
+      - nginx_latest_release.json.tag_name is defined
+      - nginx_latest_release.json.tag_name is string
+    fail_msg: "Failed to get tag_name from GitHub API response. Check API rate limits or network connectivity."
 
 - name: Download nginx-build
   get_url:

--- a/ansible/roles/nginx_build/tasks/main.yml
+++ b/ansible/roles/nginx_build/tasks/main.yml
@@ -1,6 +1,12 @@
+- name: Get latest nginx-build version
+  uri:
+    url: https://api.github.com/repos/cubicdaiya/nginx-build/releases/latest
+    body_format: json
+  register: nginx_latest_release
+
 - name: Download nginx-build
   get_url:
-    url: https://github.com/cubicdaiya/nginx-build/releases/download/v{{ nginx_build_version }}/nginx-build-linux-{{ arch_res.stdout }}-{{ nginx_build_version }}.tar.gz
+    url: "https://github.com/cubicdaiya/nginx-build/releases/download/{{ nginx_latest_release.json.tag_name }}/nginx-build-linux-{{ arch_res.stdout }}-{{ nginx_latest_release.json.tag_name | replace('v', '') }}.tar.gz"
     dest: /tmp/nginx-build-linux.tar.gz
 
 - name: Extract nginx-build

--- a/ansible/roles/nginx_build/vars/main.yml
+++ b/ansible/roles/nginx_build/vars/main.yml
@@ -1,3 +1,1 @@
 ---
-# datasource=github-releases depName=cubicdaiya/nginx-build
-nginx_build_version: 0.15.1


### PR DESCRIPTION
I modified the Ansible role `nginx_build` to dynamically fetch the latest version of nginx-build from the GitHub API instead of using a fixed version.

Changes:
- `ansible/roles/nginx_build/tasks/main.yml`:
    - Added a task to query the GitHub API for the latest release tag.
    - Updated the download URL to use the fetched latest tag.
- `ansible/roles/nginx_build/vars/main.yml`:
    - Removed the static `nginx_build_version` variable.